### PR TITLE
Autodetect

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,8 +10,8 @@ use std::{fs::File, str::FromStr};
 pub fn parse() -> (String, bool, Params, Box<dyn Read>, Box<dyn Write>) {
     let app = App::new(crate_name!())
         .version(crate_version!())
-        .arg(Arg::with_name("INPUT").required(true).help("<PATH> | -"))
-        .arg(Arg::with_name("OUTPUT").required(true).help("<PATH> | -"))
+        .arg(Arg::with_name("INPUT").help("<PATH> | - or empty for stdin"))
+        .arg(Arg::with_name("OUTPUT").help("<PATH> | - or empty for stdout"))
         .arg(
             Arg::with_name("force-encrypt")
                 .short("f")

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,4 +1,4 @@
-use crate::{ErrorKind, IoError, IoResult, ToIoResult};
+use crate::{ErrorKind, IDENTIFY, IoResult, ToIoResult};
 use aes_gcm::{
     aead::{Aead, NewAead},
     Aes256Gcm, Key, Nonce,
@@ -6,8 +6,6 @@ use aes_gcm::{
 use rand::Rng;
 pub use scrypt::{scrypt, Params};
 use std::io::{Read, Write};
-
-const IDENTIFY: &[u8; 4] = b"\xffAEF";
 
 pub const SCRYPT_LOG_N: u8 = 15;
 pub const SCRYPT_R: u32 = 8;
@@ -35,12 +33,6 @@ pub fn write_header<W: Write>(w: &mut W, salt: &[u8; 64], params: &Params) -> Io
 }
 
 pub fn read_header<R: Read>(r: &mut R) -> IoResult<([u8; 64], Params)> {
-    let mut identify = [0; 4];
-    r.read_exact(&mut identify)?;
-    if &identify != IDENTIFY {
-        return Err(IoError::new(ErrorKind::Other, "Invalid identify"));
-    }
-
     let mut salt = [0; 64];
     r.read_exact(&mut salt)?;
     let mut log_n_buf = [0; 1];

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,50 +3,67 @@ mod crypto;
 mod error;
 use crypto::{rand_salt, read_header, write_header, Cipher};
 pub use error::*;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufWriter, BufReader, Read, Write};
 
+const IDENTIFY: &[u8; 4] = b"\xffAEF";
 const BUG_SIZE: usize = 8 * 1024;
 
 fn main() {
-    let (password, params, input, output) = cli::parse();
+    let (password, force_encrypt, params, input, output) = cli::parse();
 
     let mut reader = BufReader::with_capacity(BUG_SIZE, input);
     let mut writer = BufWriter::with_capacity(BUG_SIZE, output);
 
-    match params {
-        Some(params) => {
-            let salt = rand_salt();
-            let cipher = Cipher::new(&password, &salt, &params);
-            write_header(&mut writer, &salt, &params).unwrap_exit();
-
-            let mut buf = [0; BUG_SIZE];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(n) => {
-                        cipher.write_chunk(&buf[..n], &mut writer).unwrap_exit();
-                        if n == 0 {
-                            break;
-                        }
-                    }
-                    Err(err) => exit!("{:?}", err),
-                }
+    let mut identify = vec![0; IDENTIFY.len()];
+    match reader.read(&mut identify) {
+        Ok(n) => {
+            if n < IDENTIFY.len() {
+                identify.truncate(n);
             }
         }
-        None => {
-            let (salt, params) = read_header(&mut reader).unwrap_exit();
-            let cipher = Cipher::new(&password, &salt, &params);
+        Err(err) => exit!("{:?}", err),
+    }
 
-            loop {
-                match cipher.read_chunk(&mut reader) {
-                    Ok(data) => {
-                        if data.is_empty() {
-                            break;
-                        } else {
-                            writer.write_all(&data).unwrap_exit();
-                        }
+    if identify == IDENTIFY && !force_encrypt { //we probably want to decrypt
+        let (salt, params) = read_header(&mut reader).unwrap_exit();
+        let cipher = Cipher::new(&password, &salt, &params);
+
+        loop {
+            match cipher.read_chunk(&mut reader) {
+                Ok(data) => {
+                    if data.is_empty() {
+                        break;
+                    } else {
+                        writer.write_all(&data).unwrap_exit();
                     }
-                    Err(err) => exit!("{:?}", err),
                 }
+                Err(err) => exit!("{:?}", err),
+            }
+        }
+    } else { //otherwise, encrypt
+        let salt = rand_salt();
+        let cipher = Cipher::new(&password, &salt, &params);
+        write_header(&mut writer, &salt, &params).unwrap_exit();
+
+        let mut buf = [0; BUG_SIZE];
+
+        buf[..identify.len()].clone_from_slice(&identify);
+        match reader.read(&mut buf[identify.len()..]) {
+            Ok(n) => {
+                cipher.write_chunk(&buf[..n+identify.len()], &mut writer).unwrap_exit();
+            }
+            Err(err) => exit!("{:?}", err),
+        }
+
+        loop {
+            match reader.read(&mut buf) {
+                Ok(n) => {
+                    cipher.write_chunk(&buf[..n], &mut writer).unwrap_exit();
+                    if n == 0 {
+                        break;
+                    }
+                }
+                Err(err) => exit!("{:?}", err),
             }
         }
     }


### PR DESCRIPTION
Removing the `--decrypt` flag. Instead, we check if the file is already encrypted by reading the first 4 bytes. Start decryption if this bytes match `IDENTIFY`. If we want to encrypt an already encrypted file, we can add the `--force-encrypt` flag.

I also removed the `required(true)` on `INPUT` and `OUTPUT` so we don't need to write `-` to specify the use of stdin/stdout.